### PR TITLE
Allow suppression of body in GET requests

### DIFF
--- a/drest/request.py
+++ b/drest/request.py
@@ -324,8 +324,9 @@ class RequestHandler(meta.MetaMixin):
                 
         """
         try:
-            return self._get_http().request(url, method, payload, 
-                                            headers=headers)
+            http = self._get_http()
+            return http.request(url, method, payload, headers=headers)
+
         except socket.error as e:
             # Try again just in case there was an issue with the cached _http
             try:
@@ -333,7 +334,8 @@ class RequestHandler(meta.MetaMixin):
                 return self._get_http().request(url, method, payload, 
                                                 headers=headers)
             except socket.error as e:
-                raise exc.dRestAPIError(e.args[1])
+                message = e.args[1] if len(e.args) > 1 else e.args[0]
+                raise exc.dRestAPIError(message)
         
         except ServerNotFoundError as e:
             raise exc.dRestAPIError(e.args[0])

--- a/drest/request.py
+++ b/drest/request.py
@@ -180,6 +180,7 @@ class RequestHandler(meta.MetaMixin):
         serialize = False
         deserialize = True
         trailing_slash = True
+        allow_get_body = True
         
     def __init__(self, **kw):
         super(RequestHandler, self).__init__(**kw)
@@ -387,6 +388,11 @@ class RequestHandler(meta.MetaMixin):
         else:
             payload = urlencode(params)
             
+        if method is 'GET' and not self._meta.allow_get_body:
+            payload = ''
+            if self._meta.debug:
+                print "DREST_DEBUG: supressing body for GET request"
+
         res_headers, data = self._make_request(url, method, payload,
                                                headers=headers)
         unserialized_data = data

--- a/drest/resource.py
+++ b/drest/resource.py
@@ -270,6 +270,20 @@ class TastyPieResourceHandler(RESTResourceHandler):
         pk = resource_uri.split('/')[-1]
         return self.get(pk, params)
 
+    def patch_list(self, create_objects=[], delete_objects=[]):
+        """
+        Tastypie resources have a patch_list method that allows you to create
+        and delete bulk collections of objects. This uses HTTP PATCH.
+        """
+        # ToDo: support custom collection names
+        collection_name = "objects"
+        delete_collection_name = "deleted_%s" % collection_name
+        data = {
+            collection_name: [self.filter(o) for o in create_objects],
+            delete_collection_name: delete_objects,
+        }
+        return self.api.make_request('PATCH', self.path, data)
+
     @property
     def schema(self):
         """


### PR DESCRIPTION
I've been having some issues with tastypie/drest on my lighttpd/fcgi based integration django deployment. Lighttpd seems to immediately reject any API GET requests that have a body.
Not sure if a change in drest is actually warranted - I would first ask if there's a good reason for including a body in GET requests is required? Seems like currently the same parameters are passed in via the URL and via the body. Suppressing the body seems to work fine with Tastypie, not sure about other REST implementations though.
I haven't had much luck googling for configuration changes to lighttpd that might help me.
Any help on this would be much appreciated,
Using drest with tastypie has been pretty pain free really, keep up the good work,
Oliver
