### PR TITLE
fix incorrect reference to serialiser

### DIFF
--- a/drest/request.py
+++ b/drest/request.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 
@@ -432,7 +431,7 @@ class TastyPieRequestHandler(RequestHandler):
     class Meta:
         serialize = True
         deserialize = True
-        serialization_handlerf  = serialization.JsonSerializationHandler
+        serialization_handler  = serialization.JsonSerializationHandler
         
     def __init__(self, **kw):
         super(TastyPieRequestHandler, self).__init__(**kw)


### PR DESCRIPTION
I'm trying to debug an error that only occurs with the TastyPieAPI and only when I'm using drest from my server. If I use the chrome extension Postman, I am able to correctly discover all restful data. drest however isn't able to discover any json data. If I switch to API(url) and manually add the apikey auth header then drest is able to see my restful data.

Although this may not be related to my problem, it does seem to be a minor mistake. (although I realise at the moment it doesn't matter since the base class already has its meta set to the same serialiser)
