### PR TITLE
Fixed mutable default argument bug in multiple places.

### DIFF
--- a/doc/source/customization.rst
+++ b/doc/source/customization.rst
@@ -52,7 +52,9 @@ b) what functionality you need to maintain.
         class Meta:
             request_handler = MyRequestHandler
     
-        def some_custom_function(self, params={}):
+        def some_custom_function(self, params=None):
+            if params is None:
+                params = {}
             # do some kind of custom api call
             return self.request('GET', '/users/some_custom_function', params)
 

--- a/drest/api.py
+++ b/drest/api.py
@@ -191,7 +191,11 @@ class API(meta.MetaMixin):
         """
         self.request.set_auth_credentials(user, password)
             
-    def make_request(self, method, path, params={}, headers={}):
+    def make_request(self, method, path, params=None, headers=None):
+        if params is None:
+            params = {}
+        if headers is None:
+            headers = {}
         url = "%s/%s/" % (self.baseurl.strip('/'), path.strip('/'))
         return self.request.make_request(method, url, params, headers)
         

--- a/drest/request.py
+++ b/drest/request.py
@@ -98,7 +98,7 @@ class IRequest(interface.Interface):
                 
         """
     
-    def make_request(method, path, params={}, headers={}):
+    def make_request(method, path, params=None, headers=None):
         """
         Make a request with the upstream API.
         
@@ -115,11 +115,11 @@ class IRequest(interface.Interface):
         Optional Arguments:
         
             params
-                Parameters to pass with the request.  These will be serialized
+                Dictionary of parameters to pass with the request.  These will be serialized
                 if configured to serialize.
             
             headers
-                Headers to pass to the request.
+                Dictionary of headers to pass to the request.
                 
         """
     
@@ -308,7 +308,7 @@ class RequestHandler(meta.MetaMixin):
     def _clear_http(self):
         self._http = None
             
-    def _make_request(self, url, method, payload={}, headers={}): 
+    def _make_request(self, url, method, payload=None, headers=None):
         """
         A wrapper around httplib2.Http.request.
         
@@ -329,6 +329,11 @@ class RequestHandler(meta.MetaMixin):
                 Additional headers of the request.
                 
         """
+        if payload is None:
+            payload = {}
+        if headers is None:
+            headers = {}
+
         try:
             http = self._get_http()
             return http.request(url, method, payload, headers=headers)
@@ -358,7 +363,7 @@ class RequestHandler(meta.MetaMixin):
             
         return url
         
-    def make_request(self, method, url, params={}, headers={}):
+    def make_request(self, method, url, params=None, headers=None):
         """
         Make a call to a resource based on path, and parameters.
     
@@ -382,6 +387,10 @@ class RequestHandler(meta.MetaMixin):
                 Dictionary of additional (one-time) headers of the request.
                 
         """   
+        if params is None:
+            params = {}
+        if headers is None:
+            headers = {}
         params = dict(self._extra_params, **params)
         headers = dict(self._extra_headers, **headers)
         url = self._get_complete_url(method, url, params)

--- a/drest/resource.py
+++ b/drest/resource.py
@@ -89,7 +89,7 @@ class RESTResourceHandler(ResourceHandler):
     def __init__(self, api_obj, name, path, **kw):
         super(RESTResourceHandler, self).__init__(api_obj, name, path, **kw)
 
-    def get(self, resource_id=None, params={}):
+    def get(self, resource_id=None, params=None):
         """
         Get all records for a resource, or a single resource record.
         
@@ -102,6 +102,8 @@ class RESTResourceHandler(ResourceHandler):
                 Additional request parameters to pass along.
                 
         """
+        if params is None:
+            params = {}
         if resource_id:
             path = '/%s/%s' % (self.path, resource_id)
         else:
@@ -117,11 +119,14 @@ class RESTResourceHandler(ResourceHandler):
                                         
         return response
     
-    def create(self, params={}):
+    def create(self, params=None):
         """A synonym for self.post()."""
+        if params is None:
+            params = {}
+
         return self.post(params)
         
-    def post(self, params={}):
+    def post(self, params=None):
         """
         Create a new resource.
         
@@ -131,6 +136,9 @@ class RESTResourceHandler(ResourceHandler):
                 A dictionary of parameters (different for every resource).
 
         """
+        if params is None:
+            params = {}
+
         params = self.filter(params)
         path = '/%s' % self.path
         
@@ -142,11 +150,14 @@ class RESTResourceHandler(ResourceHandler):
             
         return response
         
-    def update(self, resource_id, params={}):
+    def update(self, resource_id, params=None):
         """A synonym for self.put()."""
+        if params is None:
+            params = {}
+
         return self.put(resource_id, params)
         
-    def put(self, resource_id, params={}):
+    def put(self, resource_id, params=None):
         """
         Update an existing resource.
         
@@ -159,6 +170,8 @@ class RESTResourceHandler(ResourceHandler):
                 A dictionary of parameters (different for every resource).
                 
         """
+        if params is None:
+            params = {}
                     
         params = self.filter(params)
         path = '/%s/%s' % (self.path, resource_id)
@@ -172,7 +185,7 @@ class RESTResourceHandler(ResourceHandler):
             
         return response
         
-    def patch(self, resource_id, params={}):
+    def patch(self, resource_id, params=None):
         """
         Update only specific items of an existing resource.
         
@@ -185,6 +198,8 @@ class RESTResourceHandler(ResourceHandler):
                 A dictionary of parameters (different for every resource).
                 
         """
+        if params is None:
+            params = {}
                     
         params = self.filter(params)
         path = '/%s/%s' % (self.path, resource_id)
@@ -198,7 +213,7 @@ class RESTResourceHandler(ResourceHandler):
             
         return response
         
-    def delete(self, resource_id, params={}):
+    def delete(self, resource_id, params=None):
         """
         Delete resource record.
         
@@ -216,6 +231,8 @@ class RESTResourceHandler(ResourceHandler):
                 (normally deletion only sets the status to 'Deleted').
             
         """
+        if params is None:
+            params = {}
         path = '/%s/%s' % (self.path, resource_id)
         try:
             response = self.api.make_request('DELETE', path, params)
@@ -249,7 +266,7 @@ class TastyPieResourceHandler(RESTResourceHandler):
         super(TastyPieResourceHandler, self).__init__(api_obj, name, path, **kw)
         self._schema = None
 
-    def get_by_uri(self, resource_uri, params={}):
+    def get_by_uri(self, resource_uri, params=None):
         """
         A wrapper around self.get() that accepts a TastyPie 'resource_uri' 
         rather than a 'pk' (primary key).
@@ -269,6 +286,8 @@ class TastyPieResourceHandler(RESTResourceHandler):
             response = api.users.get_by_uri('/api/v1/users/234/')
             
         """
+        if params is None:
+            params = {}
         resource_uri = resource_uri.rstrip('/')
         pk = resource_uri.split('/')[-1]
         return self.get(pk, params)


### PR DESCRIPTION
Using mutable default arguments in Python is asking for trouble.

In using drest, I'm pretty sure that I came up against this trouble in practice - I had requests that were using headers from previous requests. My code was involved, so it's hard to track down. I did pin down a set of steps that reliably showed the problem, and after fixed all the mutable default arguments I could find, and the problem stopped. I don't know which one in particular was the fix, but they are all bugs waiting to happen.

I ran the tests, and got the same number of failures before and after.

BTW, thanks for this library, it's working really well for my use case, which requires quite a few customisations but you've already got all the hooks I need - cheers!
