### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,7 +10,7 @@ All bugs/feature details can be found at:
 Where XXXXX is the 'Issue #' referenced below.  Additionally, this change log
 is available online at:
 
-    http://drest.readthedocs.org/en/latest/changelog.html
+    https://drest.readthedocs.io/en/latest/changelog.html
 
 .. raw:: html
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Features include:
 More Information
 ----------------
 
- * RTFD: http://drest.rtfd.org/
+ * RTFD: https://drest.readthedocs.io/
  * CODE: http://github.com/datafolklabs/drest/
  * PYPI: http://pypi.python.org/pypi/drest/
  * T-CI: http://travis-ci.org/datafolklabs/drest/

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -24,7 +24,7 @@ Key Features:
 
 Additional Links:
 
-    * RTFD: `http://drest.rtfd.org/ <http://drest.rtfd.org/>`_
+    * RTFD: `https://drest.readthedocs.io/ <https://drest.readthedocs.io/>`_
     * CODE: `http://github.com/datafolklabs/drest/ <http://github.com/datafolklabs/drest/>`_
     * PYPI: `http://pypi.python.org/pypi/drest/ <http://pypi.python.org/pypi/drest/>`_
     * T-CI: `http://travis-ci.org/#!/datafolklabs/drest <http://travis-ci.org/#!/datafolklabs/drest>`_

--- a/doc/source/tastypie.rst
+++ b/doc/source/tastypie.rst
@@ -4,7 +4,7 @@ Working With Django TastyPie
 ============================
 
 dRest includes an API specifically built for the 
-`Django TastyPie <http://django-tastypie.readthedocs.org/>`_ API framework.  
+`Django TastyPie <https://django-tastypie.readthedocs.io/>`_ API framework.  
 It handles auto-detection of resources, and their schema, as well as
 other features to support the interface including getting resource data
 by 'resource_uri'.  

--- a/drest/api.py
+++ b/drest/api.py
@@ -295,7 +295,7 @@ class API(meta.MetaMixin):
 class TastyPieAPI(API):
     """
     This class implements an API client, specifically tailored for
-    interfacing with `TastyPie <http://django-tastypie.readthedocs.org/en/latest>`_.
+    interfacing with `TastyPie <https://django-tastypie.readthedocs.io/en/latest>`_.
     
     Optional / Meta Arguments:
     
@@ -364,7 +364,7 @@ class TastyPieAPI(API):
         api.users.post(data_dict)
         api.users.delete(<pk>)
         
-    What about filtering? (these depend on how the `API is configured <http://django-tastypie.readthedocs.org/en/latest/resources.html#basic-filtering>`_):
+    What about filtering? (these depend on how the `API is configured <https://django-tastypie.readthedocs.io/en/latest/resources.html#basic-filtering>`_):
     
     .. code-block:: python
     
@@ -411,7 +411,7 @@ class TastyPieAPI(API):
         """
         This authentication mechanism adds an Authorization header for 
         user/api_key per the 
-        `TastyPie Documentation <http://django-tastypie.readthedocs.org/en/latest/authentication_authorization.html>`_.
+        `TastyPie Documentation <https://django-tastypie.readthedocs.io/en/latest/authentication.html>`_.
                         
         Required Arguments:
         

--- a/drest/request.py
+++ b/drest/request.py
@@ -450,7 +450,7 @@ class RequestHandler(meta.MetaMixin):
 class TastyPieRequestHandler(RequestHandler):
     """
     This class implements the IRequest interface, specifically tailored for
-    interfacing with `TastyPie <http://django-tastypie.readthedocs.org/en/latest>`_.
+    interfacing with `TastyPie <https://django-tastypie.readthedocs.io/en/latest>`_.
 
     See :mod:`drest.request.RequestHandler` for Meta options and usage.
 

--- a/drest/resource.py
+++ b/drest/resource.py
@@ -246,7 +246,7 @@ class RESTResourceHandler(ResourceHandler):
 class TastyPieResourceHandler(RESTResourceHandler):
     """
     This class implements the IResource interface, specifically tailored for
-    interfacing with `TastyPie <http://django-tastypie.readthedocs.org/en/latest>`_.
+    interfacing with `TastyPie <https://django-tastypie.readthedocs.io/en/latest>`_.
 
     """
     class Meta:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
